### PR TITLE
Fix three code bugs

### DIFF
--- a/apps/gary/src/app/service/request.ts
+++ b/apps/gary/src/app/service/request.ts
@@ -3,8 +3,14 @@ export async function requestWithBody<T>(params: {
   options: RequestInit;
   body: T;
 }) {
+  const options = params.options ?? {};
   return fetch(params.url, {
-    ...params.options,
+    ...options,
+    method: options.method ?? 'POST',
+    headers: {
+      ...(options.headers ?? {}),
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify(params.body),
   });
 }

--- a/apps/koda/src/tasks/tasks.service.ts
+++ b/apps/koda/src/tasks/tasks.service.ts
@@ -85,14 +85,22 @@ export class TasksService {
   }
 
   async unassignTask(taskId: UUID, assignedUserId: UUID) {
+    const existingTask = await this.prisma.task.findUnique({
+      where: { id: taskId },
+      include: { assignedUser: true },
+    });
+
+    if (!existingTask) {
+      throw new NotFoundException('Task not found');
+    }
+
+    if (existingTask.assignedTo !== assignedUserId) {
+      throw new NotFoundException('Task is not assigned to the specified user');
+    }
+
     const task = await this.prisma.task.update({
-      where: {
-        id: taskId,
-        assignedTo: assignedUserId,
-      },
-      data: {
-        assignedTo: null,
-      },
+      where: { id: taskId },
+      data: { assignedTo: null },
       include: {
         project: true,
         createdByUser: true,

--- a/libs/shared/src/lib/utils/getToken.ts
+++ b/libs/shared/src/lib/utils/getToken.ts
@@ -5,9 +5,15 @@ export function getInternalApiToken({
 }: {
   serviceName: string;
 }): string {
-  const secret = process.env.INTERNAL_JWT_SECRET_KEY as string;
+  const secret = process.env.INTERNAL_JWT_SECRET_KEY;
+  if (!secret || secret.trim().length < 16) {
+    throw new Error(
+      'INTERNAL_JWT_SECRET_KEY is missing or too weak (min 16 chars).'
+    );
+  }
   return jwt.sign({ service: serviceName }, secret, {
     expiresIn: '10m',
+    algorithm: 'HS256',
   });
 }
 


### PR DESCRIPTION
Fixes `requestWithBody` headers, hardens internal JWT generation, and corrects Prisma `unassignTask` logic.

The `requestWithBody` helper now explicitly sets `Content-Type: application/json` and defaults to `POST`, preventing server rejections and incorrect method usage. Internal JWT generation now validates the secret and explicitly uses `HS256` to prevent runtime errors and ensure security. The `unassignTask` method in Prisma now correctly uses a unique selector (`id`) and includes a guard to verify the task is assigned to the specified user, resolving Prisma runtime errors and improving authorization.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6a1d12a-774f-450a-94d9-0e81c6ff22c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6a1d12a-774f-450a-94d9-0e81c6ff22c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

